### PR TITLE
Fix MoreLikeThis handler

### DIFF
--- a/3/drupal-4.3-solr-3.x/conf/solrconfig.xml
+++ b/3/drupal-4.3-solr-3.x/conf/solrconfig.xml
@@ -877,7 +877,7 @@
 
   <!-- The more like this handler offers many advantages over the standard handler,
      when performing moreLikeThis requests.-->
-  <requestHandler name="mlt" class="solr.MoreLikeThisHandler">
+  <requestHandler name="/mlt" class="solr.MoreLikeThisHandler">
     <lst name="defaults">
       <str name="mlt.mintf">1</str>
       <str name="mlt.mindf">1</str>

--- a/5/drupal-4.4-solr-5.x/conf/solrconfig.xml
+++ b/5/drupal-4.4-solr-5.x/conf/solrconfig.xml
@@ -885,7 +885,7 @@
 
   <!-- The more like this handler offers many advantages over the standard handler,
      when performing moreLikeThis requests.-->
-  <requestHandler name="mlt" class="solr.MoreLikeThisHandler">
+  <requestHandler name="/mlt" class="solr.MoreLikeThisHandler">
     <lst name="defaults">
       <str name="mlt.mintf">1</str>
       <str name="mlt.mindf">1</str>

--- a/6/drupal-5.2-solr-6.x/conf/solrconfig.xml
+++ b/6/drupal-5.2-solr-6.x/conf/solrconfig.xml
@@ -858,7 +858,7 @@
 
   <!-- The more like this handler offers many advantages over the standard handler,
      when performing moreLikeThis requests.-->
-  <requestHandler name="mlt" class="solr.MoreLikeThisHandler">
+  <requestHandler name="/mlt" class="solr.MoreLikeThisHandler">
     <lst name="defaults">
       <str name="df">content</str>
       <str name="mlt.mintf">1</str>


### PR DESCRIPTION
the MLT handler was missing a leading slash, causing the path to 404. This small patch resolves that.